### PR TITLE
Fix deploy.sh and readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # heroku-docker-automuteus
+
 Unofficial AutoMuteUs docker image for Heroku deployment
 
 ## How to use
@@ -7,6 +8,8 @@ Unofficial AutoMuteUs docker image for Heroku deployment
 
 - Configured [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli)
 - heroku-config plugin (will be installed automatically)
+- [heroku billing setting](https://heroku.com/verify)
+- [Docker](https://docs.docker.com/get-docker/)
 
 ### Steps
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -43,6 +43,7 @@ function update_app() {
   fi
   heroku config:push -a "${app_name}"
 
+  heroku container:login
   heroku container:push --recursive -a "${app_name}"
   heroku container:release web -a "${app_name}"
 }


### PR DESCRIPTION
Hi @k-tahiro.
I really appreciate your shell script because I'm not familiar with docker and Heroku.
I found 3 issues and fixed it with this PR.

- Updated Deploy.sh to avoid `no basic auth credentials`.
  - https://qiita.com/SuguruOoki/items/9a0b4a5a3876ebc9b9fb

- Updated Readme to avoid two errors.
1. 
      ```
       ▸    Please verify your account to install this add-on plan (please enter a
       ▸    credit card) For more information, see
       ▸    https://devcenter.heroku.com/categories/billing Verify now at
       ▸    https://heroku.com/verify
      ```

2.
      ```
       ▸    Error: docker build exited with Error: Cannot find docker, please ensure
       ▸    docker is installed.
       ▸    If you need help installing docker, visit
       ▸    https://docs.docker.com/install/#supported-platforms
      ```

Thanks.